### PR TITLE
fix(lib): update Emacs terminal detection in `title` function (#9577)

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -10,7 +10,7 @@ function title {
   emulate -L zsh
   setopt prompt_subst
 
-  [[ "$EMACS" == *term* ]] && return
+  [[ "$INSIDE_EMACS" == *term* ]] && return
 
   # if $2 is unset use $1 as default
   # if it is set and empty, leave it as is


### PR DESCRIPTION
Environment variable EMACS was replaced by INSIDE_EMACS

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
